### PR TITLE
Adding valid defaults to migration table for timestamps to fix issue with bootstrapping mysql

### DIFF
--- a/agnostic/__init__.py
+++ b/agnostic/__init__.py
@@ -13,8 +13,8 @@ MIGRATION_TABLE_SQL = '''
     CREATE TABLE agnostic_migrations (
         name VARCHAR(255) PRIMARY KEY,
         status VARCHAR(255),
-        started_at TIMESTAMP,
-        completed_at TIMESTAMP
+        started_at TIMESTAMP DEFAULT NOW(),
+        completed_at TIMESTAMP DEFAULT NOW()
     )
 '''
 

--- a/agnostic/__init__.py
+++ b/agnostic/__init__.py
@@ -9,11 +9,15 @@ MigrationStatus = Enum(
 )
 
 
+# Different databases treat timestamp columns differently, e.g. MySQL will
+# automatically coerce `null` to `now()``! To be defensive, we explicitly
+# include the `NULL DEFAULT NULL` for nullable fields, even though it might
+# be redundant in ANSI SQL.
 MIGRATION_TABLE_SQL = '''
     CREATE TABLE agnostic_migrations (
         name VARCHAR(255) PRIMARY KEY,
-        status VARCHAR(255),
-        started_at TIMESTAMP DEFAULT NOW(),
+        status VARCHAR(255) NULL DEFAULT NULL,
+        started_at TIMESTAMP NULL DEFAULT NULL,
         completed_at TIMESTAMP NULL DEFAULT NULL
     )
 '''

--- a/agnostic/__init__.py
+++ b/agnostic/__init__.py
@@ -14,7 +14,7 @@ MIGRATION_TABLE_SQL = '''
         name VARCHAR(255) PRIMARY KEY,
         status VARCHAR(255),
         started_at TIMESTAMP DEFAULT NOW(),
-        completed_at TIMESTAMP DEFAULT NOW()
+        completed_at TIMESTAMP NULL DEFAULT NULL
     )
 '''
 


### PR DESCRIPTION
I received the following error when bootstrapping agnostic on a mysql database:
```
Error: Failed to create migration table: (1067, "Invalid default value for 'completed_at'")
```

I simply added `NOW()` as the default on the `MIGRATION_TABLE_SQL` constant for the `TIMESTAMP` columns.  This is the value given with the `bootstrap_migration()` method for agnostic anyway, so I assumed it should be fine.

Setting the defaults fixed the issue on my end.